### PR TITLE
修复“无法获取用户头像”的问题

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -25,9 +25,11 @@ export function session(native: NativeSession): types.Session {
 
 export function user(native: native.User): types.Profile {
   const username = Number(native.username);
+  const hasAvatar = Reflect.has(native, 'avatar');
   return {
     uuid: native.id,
     isBot: native.is_bot,
+    avatar: hasAvatar ? Reflect.get(native, 'avatar') : undefined,
     name: native.first_name,
     id: Number.isNaN(username) ? undefined : username, // 机器人 username 是字符串
     privacyMode: native.can_read_all_group_messages,

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -11,6 +11,10 @@ export interface Profile {
    */
   isBot?: boolean;
   /**
+   * 头像地址。
+   */
+  avatar?: string;
+  /**
    * 用户昵称。
    */
   name: string;


### PR DESCRIPTION
由于官方文档中没有注明这个属性，所以需要使用 `Reflect` 库获取属性。