### PR TITLE
“分页获取频道成员列表”接口允许传入机器人信息

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -74,6 +74,11 @@ export interface GetChannelMembersConfig {
   channel: bigint;
   /** 分页数据。 */
   range: native.Range;
+  /**
+   * 机器人资料。
+   * @default await this.getMe()
+   */
+  profile?: types.Profile;
 }
 export interface GetUserByShortIdConfig {
   /** 用户所在频道 ID 。 */
@@ -276,8 +281,9 @@ export class Bot {
     guild,
     channel,
     range,
+    profile,
   }: GetChannelMembersConfig): Promise<bigint[]> {
-    const user = (await this.getProfile()).uuid;
+    const user = (profile ?? await this.getProfile()).uuid;
     const res: {
       ops: Array<{
         range: [number, number];


### PR DESCRIPTION
commit 06107210989d6bac57571862c018006af67e3dae 中的提交信息有误，应删去“成员”二字。